### PR TITLE
Revert "Don't let nginx write redundant output."

### DIFF
--- a/src/nginx/supply/supply.go
+++ b/src/nginx/supply/supply.go
@@ -181,7 +181,7 @@ func (s *Supplier) validateNginxConfSyntax() error {
 	}
 
 	nginxExecDir := filepath.Join(s.Stager.DepDir(), "nginx", "nginx", "sbin")
-	if err := s.Command.Execute(tmpConfDir, ioutil.Discard, ioutil.Discard, filepath.Join(nginxExecDir, "nginx"), "-t", "-c", nginxConfPath, "-p", tmpConfDir); err != nil {
+	if err := s.Command.Execute(tmpConfDir, os.Stdout, os.Stderr, filepath.Join(nginxExecDir, "nginx"), "-t", "-c", nginxConfPath, "-p", tmpConfDir); err != nil {
 		return fmt.Errorf("nginx.conf contains syntax errors: %s", err.Error())
 	}
 	return nil


### PR DESCRIPTION
This commit suppressed useful output. Compare:

```
[myapp] 2018-04-01T05:04:26.087311800Z        Copy [/tmp/cache/final/dependencies/3f403d63332178328a50a09e70a6ecbf72e52adc936e99fa56730fe284e75920/nginx-1.13.10-linux-x64-69d36c67.tgz]
[myapp] 2018-04-01T05:04:26.210755700Z        **ERROR** Could not validate nginx.conf: nginx.conf contains syntax errors: exit status 1
[myapp] 2018-04-01T05:04:26.214792000Z Failed to compile droplet: Failed to run all supply scripts: exit status 14
```
vs.
```
[myapp] 2018-04-01T05:04:56.773865700Z        Copy [/tmp/cache/final/dependencies/3f403d63332178328a50a09e70a6ecbf72e52adc936e99fa56730fe284e75920/nginx-1.13.10-linux-x64-69d36c67.tgz]
[myapp] 2018-04-01T05:04:56.972035400Z 2018/04/01 05:04:56 [emerg] 144#0: invalid number of arguments in "default_type" directive in /tmp/conf444741750/nginx.conf:14
[myapp] 2018-04-01T05:04:56.974379500Z nginx: configuration file /tmp/conf444741750/nginx.conf test failed
[myapp] 2018-04-01T05:04:56.980698100Z        **ERROR** Could not validate nginx.conf: nginx.conf contains syntax errors: exit status 1
[myapp] 2018-04-01T05:04:56.982157700Z Failed to compile droplet: Failed to run all supply scripts: exit status 14
```

Instead of suppressing the output from NGINX, could we skip printing the `: exit status 1`, which doesn't seem meaningful?

Also, not passing stdout/stderr to NGINX prevents it from validating that the fds and writable. Before this commit, the buildpack would correctly detect during staging when it would not be able to log during launch (in old CF Local and garden-linux):
```
[nginx] 2018-03-29T19:40:15.725469709Z nginx: the configuration file /tmp/conf120673671/nginx.conf syntax is ok
[nginx] 2018-03-29T19:40:15.732597343Z 2018/03/29 19:40:15 [emerg] 167#0: open() "/dev/stdout" failed (13: Permission denied)
[nginx] 2018-03-29T19:40:15.732681202Z nginx: configuration file /tmp/conf120673671/nginx.conf test failed
[nginx] 2018-03-29T19:40:15.736316083Z        **ERROR** Could not validate nginx.conf: nginx.conf contains syntax errors: exit status 1
```