### PR TITLE
Setup brats environment

### DIFF
--- a/scripts/brats.sh
+++ b/scripts/brats.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 
 export ROOT="$( dirname "${BASH_SOURCE[0]}" )/.."
+source .envrc
 $ROOT/scripts/install_tools.sh
 
 GINKGO_NODES=${GINKGO_NODES:-3}


### PR DESCRIPTION
Go tools can not be executed without the environment variables from
.envrc.

### A short explanation of the proposed change:
Load environment variables during brats run.

### An explanation of the use cases your change solves
Being able to run the go tools like ginko. Unlike the other buildpack brats scripts, envrc was not loaded in this one so the ginko call inside of the brats.sh failed at least in our environment.
