### PR TITLE
{{nameservers}} parameters fix

### DIFF
--- a/src/nginx/supply/supply.go
+++ b/src/nginx/supply/supply.go
@@ -263,7 +263,7 @@ func (s *Supplier) validateNginxConfHasPort() error {
 		"module": func(arg string) string {
 			return ""
 		},
-		"nameservers": func(arg string) string {
+		"nameservers": func() string {
 			return ""
 		},
 	}


### PR DESCRIPTION
The bug https://github.com/cloudfoundry/nginx-buildpack/issues/24 fix.