### PR TITLE
Updating version for openresty for 1.19.X

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -53,13 +53,13 @@ dependencies:
   source: http://openresty.org/download/openresty-1.17.8.2.tar.gz
   source_sha256: 2f321ab11cb228117c840168f37094ee97f8f0316eac413766305409c7e023a0
 - name: openresty
-  version: 1.19.3.1
-  uri: https://buildpacks.cloudfoundry.org/dependencies/openresty/openresty_1.19.3.1_linux_x64_cflinuxfs3_942fc5f7.tgz
-  sha256: 942fc5f7002d42ed1ca3f545675dd324d3ee50e1484b0dfc182f22b475b29b00
+  version: 1.19.3.2
+  uri: https://buildpacks.cloudfoundry.org/dependencies/openresty/openresty_1.19.3.2_linux_x64_cflinuxfs3_acefa176.tgz
+  sha256: acefa1761c1aaab63e39da95d52c5cfa0b8143419be8418d14dd587df5984f67
   cf_stacks:
   - cflinuxfs3
-  source: http://openresty.org/download/openresty-1.19.3.1.tar.gz
-  source_sha256: f36fcd9c51f4f9eb8aaab8c7f9e21018d5ce97694315b19cacd6ccf53ab03d5d
+  source: http://openresty.org/download/openresty-1.19.3.2.tar.gz
+  source_sha256: ce40e764990fbbeb782e496eb63e214bf19b6f301a453d13f70c4f363d1e5bb9
 pre_package: scripts/build.sh
 include_files:
 - CHANGELOG


### PR DESCRIPTION
This PR is made automatically by release engineering bot.