### PR TITLE
Updating version for openresty for 1.19.X

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -57,13 +57,13 @@ dependencies:
   source: http://openresty.org/download/openresty-1.17.8.2.tar.gz
   source_sha256: 2f321ab11cb228117c840168f37094ee97f8f0316eac413766305409c7e023a0
 - name: openresty
-  version: 1.19.3.2
-  uri: https://buildpacks.cloudfoundry.org/dependencies/openresty/openresty_1.19.3.2_linux_x64_cflinuxfs3_acefa176.tgz
-  sha256: acefa1761c1aaab63e39da95d52c5cfa0b8143419be8418d14dd587df5984f67
+  version: 1.19.9.1
+  uri: https://buildpacks.cloudfoundry.org/dependencies/openresty/openresty_1.19.9.1_linux_x64_cflinuxfs3_60c6c2df.tgz
+  sha256: 60c6c2df81ab821cc6695cc7b44b68cbf77dba4aa89b21c15753c4356b4f43d9
   cf_stacks:
   - cflinuxfs3
-  source: http://openresty.org/download/openresty-1.19.3.2.tar.gz
-  source_sha256: ce40e764990fbbeb782e496eb63e214bf19b6f301a453d13f70c4f363d1e5bb9
+  source: http://openresty.org/download/openresty-1.19.9.1.tar.gz
+  source_sha256: 576ff4e546e3301ce474deef9345522b7ef3a9d172600c62057f182f3a68c1f6
 pre_package: scripts/build.sh
 include_files:
 - CHANGELOG


### PR DESCRIPTION
This PR is made automatically by release engineering bot.