### PR TITLE
Update fixtures and manifest.yml to handle new versions

### DIFF
--- a/fixtures/overrideyml_bp/override.yml
+++ b/fixtures/overrideyml_bp/override.yml
@@ -1,7 +1,7 @@
 nginx:
   dependencies:
   - name: nginx
-    version: 1.23.999
+    version: 1.25.999
     uri: https://buildpacks.cloudfoundry.org/dependencies/nginx/nginx-1.23.999-linux-x64.tgz
     file: BUILDPACK_DIR/nginx.tgz
     sha256: 062d906c87839d03b243e2821e10653c89b4c92878bfe2bf995dec231e117bfc

--- a/manifest.yml
+++ b/manifest.yml
@@ -2,7 +2,7 @@
 language: nginx
 default_versions:
 - name: nginx
-  version: 1.23.x
+  version: 1.25.x
 version_lines:
   mainline: 1.25.x
   stable: 1.24.x

--- a/src/nginx/integration/deploy_an_app_test.go
+++ b/src/nginx/integration/deploy_an_app_test.go
@@ -82,7 +82,7 @@ var _ = Describe("CF Nginx Buildpack", func() {
 		It("Uses latest mainline nginx", func() {
 			PushAppAndConfirm(app)
 
-			Eventually(app.Stdout.String).Should(ContainSubstring(`No nginx version specified - using mainline => 1.23.`))
+			Eventually(app.Stdout.String).Should(ContainSubstring(`No nginx version specified - using mainline => 1.25.`))
 			Eventually(app.Stdout.String).ShouldNot(ContainSubstring(`Requested nginx version:`))
 
 			Expect(app.GetBody("/")).To(ContainSubstring("Exciting Content"))
@@ -98,7 +98,7 @@ var _ = Describe("CF Nginx Buildpack", func() {
 		It("Logs nginx buildpack version", func() {
 			PushAppAndConfirm(app)
 
-			Eventually(app.Stdout.String).Should(ContainSubstring(`Requested nginx version: mainline => 1.23.`))
+			Eventually(app.Stdout.String).Should(ContainSubstring(`Requested nginx version: mainline => 1.25.`))
 
 			Expect(app.GetBody("/")).To(ContainSubstring("Exciting Content"))
 			Eventually(app.Stdout.String).Should(ContainSubstring(`NginxLog "GET / HTTP/1.1" 200`))
@@ -113,7 +113,7 @@ var _ = Describe("CF Nginx Buildpack", func() {
 		It("Logs nginx buildpack version", func() {
 			PushAppAndConfirm(app)
 
-			Eventually(app.Stdout.String).Should(ContainSubstring(`Requested nginx version: stable => 1.22.`))
+			Eventually(app.Stdout.String).Should(ContainSubstring(`Requested nginx version: stable => 1.24.`))
 			Eventually(app.Stdout.String).Should(ContainSubstring(`Warning: usage of "stable" versions of NGINX is discouraged in most cases by the NGINX team.`))
 
 			Expect(app.GetBody("/")).To(ContainSubstring("Exciting Content"))
@@ -128,7 +128,7 @@ var _ = Describe("CF Nginx Buildpack", func() {
 
 		It("Logs nginx buildpack versions", func() {
 			Expect(app.Push()).ToNot(Succeed())
-			Eventually(app.Stdout.String).Should(ContainSubstring(`Available versions: mainline, stable, 1.22.x, 1.23.x`))
+			Eventually(app.Stdout.String).Should(ContainSubstring(`Available versions: mainline, stable, 1.24.x, 1.25.x`))
 		})
 	})
 


### PR DESCRIPTION
Update fixtures and manifest.yml to handle new versions:

- mainline: 1.25.x
- stable: 1.24.x