### PR TITLE
supply: when {{port}} validation fails, log it clearly

### DIFF
--- a/src/nginx/integration/deploy_an_app_with_errors_test.go
+++ b/src/nginx/integration/deploy_an_app_with_errors_test.go
@@ -56,7 +56,7 @@ var _ = Describe("CF Nginx Buildpack", func() {
 			Expect(app.Push()).ToNot(Succeed())
 			Expect(app.ConfirmBuildpack(buildpackVersion)).To(Succeed())
 
-			Eventually(app.Stdout.String).Should(ContainSubstring("nginx.conf file must be configured to respect the value of `{{port}}`"))
+			Eventually(app.Stdout.String).Should(ContainSubstring("The listen port value in nginx.conf must be configured to the template `{{port}}`"))
 		})
 	})
 })

--- a/src/nginx/supply/mocks_test.go
+++ b/src/nginx/supply/mocks_test.go
@@ -89,6 +89,21 @@ func (mr *MockCommandMockRecorder) Run(cmd interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Run", reflect.TypeOf((*MockCommand)(nil).Run), cmd)
 }
 
+// RunWithOutput mocks base method.
+func (m *MockCommand) RunWithOutput(cmd *exec.Cmd) ([]byte, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RunWithOutput", cmd)
+	ret0, _ := ret[0].([]byte)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// RunWithOutput indicates an expected call of RunWithOutput.
+func (mr *MockCommandMockRecorder) RunWithOutput(cmd interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RunWithOutput", reflect.TypeOf((*MockCommand)(nil).RunWithOutput), cmd)
+}
+
 // MockManifest is a mock of Manifest interface.
 type MockManifest struct {
 	ctrl     *gomock.Controller


### PR DESCRIPTION
Previously, only the final error return statement in `validateNginxConfHasPort()` would log the message that the `{{port}}` template is missing. On any errors before that statement (like `varify` returning exit 1), no messages were logged that lets a user know that `{{port}}` template is missing for the `listen` directive.

Fixes https://github.com/cloudfoundry/nginx-buildpack/issues/253