### PR TITLE
Fix integration tests after promotion of mainline from 1.28.x to 1.29.x

### DIFF
--- a/fixtures/util/override_buildpack/override.yml
+++ b/fixtures/util/override_buildpack/override.yml
@@ -10,3 +10,4 @@ nginx:
     cf_stacks:
     - cflinuxfs3
     - cflinuxfs4
+    - cflinuxfs5

--- a/src/nginx/integration/default_test.go
+++ b/src/nginx/integration/default_test.go
@@ -114,7 +114,7 @@ func testDefault(platform switchblade.Platform, fixtures string) func(*testing.T
 					Execute(name, filepath.Join(fixtures, "default", "unspecified_version"))
 				Expect(err).NotTo(HaveOccurred())
 
-				Eventually(logs).Should(ContainSubstring(`No nginx version specified - using mainline => 1.28.`))
+				Eventually(logs).Should(ContainSubstring(`No nginx version specified - using mainline => 1.29.`))
 				Eventually(logs).ShouldNot(ContainSubstring(`Requested nginx version:`))
 
 				Eventually(deployment).Should(Serve(ContainSubstring("Exciting Content")))
@@ -133,7 +133,7 @@ func testDefault(platform switchblade.Platform, fixtures string) func(*testing.T
 					Execute(name, filepath.Join(fixtures, "default", "mainline"))
 				Expect(err).NotTo(HaveOccurred())
 
-				Eventually(logs).Should(ContainSubstring(`Requested nginx version: mainline => 1.28.`))
+				Eventually(logs).Should(ContainSubstring(`Requested nginx version: mainline => 1.29.`))
 
 				Eventually(deployment).Should(Serve(ContainSubstring("Exciting Content")))
 
@@ -170,7 +170,7 @@ func testDefault(platform switchblade.Platform, fixtures string) func(*testing.T
 					Execute(name, filepath.Join(fixtures, "default", "unavailable_version"))
 				Expect(err).To(HaveOccurred())
 
-				Eventually(logs).Should(ContainSubstring(`Available versions: mainline, stable, 1.28.x, 1.29.x`))
+				Eventually(logs).Should(ContainSubstring(`Available versions: mainline, stable, 1.29.x, 1.29.x`))
 			})
 		})
 


### PR DESCRIPTION
## Summary

Update integration test expectations and override buildpack fixture to
reflect the promotion of `mainline` from `1.28.x` to `1.29.x`.

## Changes

### `src/nginx/integration/default_test.go`
- Update expected log output for "no version specified" test:
  `using mainline => 1.28.` → `using mainline => 1.29.`
- Update expected log output for "specifying mainline" test:
  `Requested nginx version: mainline => 1.28.` → `mainline => 1.29.`
- Update expected available versions string:
  `mainline, stable, 1.28.x, 1.29.x` → `mainline, stable, 1.29.x, 1.29.x`
  (both `mainline` and `stable` now resolve to `1.29.x`)

### `fixtures/util/override_buildpack/override.yml`
- Add `cflinuxfs5` to `cf_stacks` for the override dependency so the
  sha mismatch test behaves correctly when running against cflinuxfs5.
  Without this, the override dep is not matched on cflinuxfs5 and the
  buildpack falls back to the real dependency, causing staging to succeed
  instead of failing as expected.